### PR TITLE
Add new `AdTargetingAnalyticsStream` stream

### DIFF
--- a/tap_pinterest_ads/tap.py
+++ b/tap_pinterest_ads/tap.py
@@ -11,6 +11,7 @@ from tap_pinterest_ads.streams import (
     AdGroupStream,
     AdStream,
     AdAnalyticsStream,
+    AdTargetingAnalyticsStream,
     AccountAnalyticsStream
 )
 STREAM_TYPES = [
@@ -19,6 +20,7 @@ STREAM_TYPES = [
     AdGroupStream,
     AdStream,
     AdAnalyticsStream,
+    AdTargetingAnalyticsStream,
     AccountAnalyticsStream
 ]
 


### PR DESCRIPTION
## What was done?

The Pinterest Ads API supports getting [targeting analytics for ads](https://developers.pinterest.com/docs/api/v5/ad_targeting_analytics-get), allowing for reporting on various breakdowns such as country, region, etc. However, the `tap-pinterest-ads` tap does not currently have a stream to pull this data.

This PR adds a new stream - `AdTargetingAnalyticsStream` - that fetches data for all currently supported targeting types (`AGE_BUCKET_AND_GENDER` targeting type has been omitted as it is in beta and not currently available to all users).

The `AdTargetingAnalyticsStream` is a subclass of `AdAnalyticsStream`, and leverages the bulk of the parent class code; however, it has a custom `post_process` method that transforms the record returned by the API so that it more closely resembles the rows produced by the `AdAnalyticsStream`. For example, the following is an example of a record returned by the API:

```json
{
  "targeting_type": "KEYWORD",
  "targeting_value": "christmas decor ideas",
  "metrics": {
    "AD_GROUP_ID": 2680067996745,
    "DATE": "2022-04-26",
    "SPEND_IN_DOLLAR": 240
  }
}
```

The `post_process` function flattens the `metrics` structure into the root document, so that it looks like the following (**Note:** All column names have been capitalized to match the naming convention of the current `AdAnalyticsStream` columns):

```json
{
  "TARGETING_TYPE": "KEYWORD",
  "TARGETING_VALUE": "christmas decor ideas",
  "AD_GROUP_ID": 2680067996745,
  "DATE": "2022-04-26",
  "SPEND_IN_DOLLAR": 240
}
```

The `parent_stream_type` property of the `AdTargetingAnalyticsStream` is set to `AdStream` as the `targeting_analytics` API endpoint requires that at least one ad ID be passed as a parameter when querying the API. Thus, once an ad has been extracted in the parent stream, the `ad_id` is set in the `context` that is passed to the child stream, allowing the stream to query the targeting analytics for each ad extracted by the `AdStream`.